### PR TITLE
.gitignore: Replace .rvmrc with the standard .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.rvmrc
+/.ruby-version
 temp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /.ruby-version
-temp/
+/temp/


### PR DESCRIPTION
The latter is the modern standard.