### PR TITLE
Clean all the warnings

### DIFF
--- a/lib/spreadbase/codecs/open_document_12_modules/decoding.rb
+++ b/lib/spreadbase/codecs/open_document_12_modules/decoding.rb
@@ -115,7 +115,7 @@ module SpreadBase # :nodoc:
 
             if float_string.include?('.')
               if floats_as_bigdecimal
-                BigDecimal.new(float_string)
+                BigDecimal(float_string)
               else
                 float_string.to_f
               end

--- a/lib/spreadbase/codecs/open_document_12_modules/encoding.rb
+++ b/lib/spreadbase/codecs/open_document_12_modules/encoding.rb
@@ -146,7 +146,7 @@ module SpreadBase # :nodoc:
             cell_node.attributes['office:value-type'] = 'float'
 
             cell_node.attributes['office:value'] = value.to_s('F')
-          when Float, Fixnum
+          when Float, Integer
             cell_node.attributes['office:value-type'] = 'float'
 
             cell_node.attributes['office:value'] = value.to_s

--- a/lib/spreadbase/document.rb
+++ b/lib/spreadbase/document.rb
@@ -28,7 +28,7 @@ module SpreadBase # :nodoc:
       @document_path = document_path
       @options       = options.clone
 
-      if @document_path && File.exists?(document_path)
+      if @document_path && File.exist?(document_path)
         document_archive = IO.read(document_path)
         decoded_document = Codecs::OpenDocument12.new.decode_archive(document_archive, options)
 

--- a/lib/spreadbase/helpers/helpers.rb
+++ b/lib/spreadbase/helpers/helpers.rb
@@ -11,7 +11,7 @@ module SpreadBase # :nodoc:
     def make_array_from_repetitions(instance, repetitions)
       (1..repetitions).inject([]) do | cumulative_result, i |
         case instance
-        when Fixnum, Float, BigDecimal, Date, Time, TrueClass, FalseClass, NilClass #, DateTime is a Date
+        when Integer, Float, BigDecimal, Date, Time, TrueClass, FalseClass, NilClass #, DateTime is a Date
           cumulative_result << instance
         when String, Array
           cumulative_result << instance.clone

--- a/lib/spreadbase/table.rb
+++ b/lib/spreadbase/table.rb
@@ -304,7 +304,7 @@ module SpreadBase # :nodoc:
     # _returns_ a 0-based decimal number.
     #
     def decode_column_identifier(column_identifier)
-      if column_identifier.is_a?(Fixnum)
+      if column_identifier.is_a?(Integer)
         raise "Negative column indexes not allowed: #{ column_identifier }" if column_identifier < 0
 
         column_identifier

--- a/spec/codecs/open_document_12_spec.rb
+++ b/spec/codecs/open_document_12_spec.rb
@@ -41,7 +41,7 @@ describe SpreadBase::Codecs::OpenDocument12 do
 
         assert_size(row_1, 3) do | value_1, value_2, value_3 |
           expect(value_1).to eq(1)
-          expect(value_1).to be_a(Fixnum)
+          expect(value_1).to be_a(Integer)
           expect(value_2).to eq(1.1)
           expect(value_2).to be_a(BigDecimal)
           expect(value_3).to eq(T_BIGDECIMAL)

--- a/spec/elements/document_spec.rb
+++ b/spec/elements/document_spec.rb
@@ -33,7 +33,7 @@ describe SpreadBase::Document do
   it "should initialize from a file" do
     codec = stub_initializer(SpreadBase::Codecs::OpenDocument12)
 
-    expect(File).to receive(:'exists?').with('/pizza/margerita.txt').and_return(true)
+    expect(File).to receive(:'exist?').with('/pizza/margerita.txt').and_return(true)
     expect(IO).to receive(:read).with('/pizza/margerita.txt').and_return('abc')
     expect(codec).to receive(:decode_archive).with('abc', {}).and_return(@sample_document)
 

--- a/spec/elements/document_spec.rb
+++ b/spec/elements/document_spec.rb
@@ -46,8 +46,6 @@ describe SpreadBase::Document do
   end
 
   it "should initialize with a non-existing file" do
-    codec = stub_initializer(SpreadBase::Codecs::OpenDocument12)
-
     document = SpreadBase::Document.new('/pizza/margerita.txt')
 
     assert_size(document.tables, 0)

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -6,7 +6,7 @@ module SpecHelpers
   T_DATE       = Date.new(2012, 4, 10)
   T_DATETIME   = DateTime.new(2012, 4, 11, 23, 33, 42)
   T_TIME       = Time.new(2012, 4, 11, 23, 33, 42, "+02:00")
-  T_BIGDECIMAL = BigDecimal.new('1.33')
+  T_BIGDECIMAL = BigDecimal('1.33')
 
   # This method is cool beyond any argument about the imperfect name.
   #


### PR DESCRIPTION
Cleaned all the warnings, most notably, replaced `Fixnum` with `Integer`.

Closes #9.