### PR TITLE
Replace ZipRuby gem with RubyZip gem

### DIFF
--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.description = %q{Library for reading/writing OpenOffice Calc documents.}
   s.license     = "GPL-3.0"
 
-  s.add_runtime_dependency     "zipruby", "~>0.3.6"
+  s.add_runtime_dependency     "rubyzip", ">=1.3.0"
   s.add_development_dependency "rspec",   "~>3.9.0"
 
   s.add_development_dependency "rake",   "~>13.0"


### PR DESCRIPTION
Hi @saveriomiroddi ,

First, thank you for sharing your impressive Gem !

----

This PR is to replace `zipruby` gem with `rubyzip` gem.

It's seemed that `zipruby` gem is no longer maintained so I think `rubyzip` gem is more preferred.
(In fact I tried to install `zipruby` on Windows 10 but failed.)

In addition, gems to manipulate MS Excel, e.g. [rubyXL](https://github.com/weshatheleopard/rubyXL), [axls](https://github.com/caxlsx/caxlsx), use  `rubyzip` gem.
I also think gem manipulating ZIP file should be unified.
