### PR TITLE
Drop Ruby 2.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['3.0', '2.7', '2.6', '2.5', '2.4', '2.3']
+        ruby: ['3.0', '2.7', '2.6', '2.5', '2.4']
 
     steps:
       - name: Checkout spreadbase repository

--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.name        = "spreadbase"
   s.version     = SpreadBase::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.authors     = ["Saverio Miroddi"]
   s.date        = '2021-03-05'
   s.email       = ["saverio.pub2@gmail.com"]


### PR DESCRIPTION
Version 2.3 is very old; even 2.4 is discontinued. Dropping support for 2.3 allows using the latest Rubyzip gem version.