### PR TITLE
Update and restrict `rubyzip` dependency

### DIFF
--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.description = %q{Library for reading/writing OpenOffice Calc documents.}
   s.license     = "GPL-3.0"
 
-  s.add_runtime_dependency     "rubyzip", ">=1.3.0"
+  s.add_runtime_dependency     "rubyzip", "~>2.3.0"
   s.add_development_dependency "rspec",   "~>3.9.0"
 
   s.add_development_dependency "rake",   "~>13.0"


### PR DESCRIPTION
It was open-ended, which also causes a warning when releasing the gem.

While restricting it, it's also been updated to the latest version.

Closes #22.