### PR TITLE
support rubyzip version 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.0', '2.7', '2.6', '2.5', '2.4']
+        use_rubyzip_3: ['yes', 'no']
+
+    env:
+      USE_RUBYZIP_3: ${{ matrix.use_rubyzip_3 }}
 
     steps:
       - name: Checkout spreadbase repository

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,13 @@ gemspec
 if Gem.ruby_version >= Gem::Version.new('3.0.0')
   gem 'rexml'
 end
+
+if ENV['USE_RUBYZIP_3'] == 'yes'
+  if gemspec_cache = Bundler.instance_variable_get(:@gemspec_cache)
+    gemspec_cache
+      .values
+      .find { |s| s.name == 'spreadbase' }
+      .dependencies.delete_if { |d| d.name == 'rubyzip' }
+  end
+  gem 'rubyzip', github: 'rubyzip/rubyzip'
+end

--- a/lib/spreadbase/codecs/open_document_12.rb
+++ b/lib/spreadbase/codecs/open_document_12.rb
@@ -59,8 +59,7 @@ module SpreadBase # :nodoc:
       # _returns_ the SpreadBase::Document instance.
       #
       def decode_archive(zip_buffer, options={})
-        io = StringIO.new(zip_buffer)
-        content_xml_data = Zip::File.new(io, false, true).read('content.xml')
+        content_xml_data = read_content_xml(zip_buffer)
 
         decode_content_xml(content_xml_data, options)
       end
@@ -105,6 +104,19 @@ module SpreadBase # :nodoc:
       end
 
       private
+
+      def read_content_xml(zip_buffer)
+        io = StringIO.new(zip_buffer)
+        if use_rubyzip_3?
+          Zip::File.new(io, buffer: true).read('content.xml')
+        else
+          Zip::File.new(io, false, true).read('content.xml')
+        end
+      end
+
+      def use_rubyzip_3?
+        Gem.loaded_specs['rubyzip'].version >= Gem::Version.create('3.0.0')
+      end
 
       def pretty_xml(document)
         buffer = ""


### PR DESCRIPTION
Hi @64kramsystem ,

The rubyzip gem is now being developed and its version is `3.0.0`.
https://github.com/rubyzip/rubyzip/blob/master/lib/zip/version.rb

This PR is to fix errors happened when rubyzip v3 is used.