### PR TITLE
Add support for Rubyzip 3.0

### DIFF
--- a/lib/spreadbase/codecs/open_document_12.rb
+++ b/lib/spreadbase/codecs/open_document_12.rb
@@ -59,8 +59,7 @@ module SpreadBase # :nodoc:
       # _returns_ the SpreadBase::Document instance.
       #
       def decode_archive(zip_buffer, options={})
-        io = StringIO.new(zip_buffer)
-        content_xml_data = Zip::File.new(io, false, true).read('content.xml')
+        content_xml_data = read_content_xml(zip_buffer)
 
         decode_content_xml(content_xml_data, options)
       end
@@ -105,6 +104,22 @@ module SpreadBase # :nodoc:
       end
 
       private
+
+      def read_content_xml(zip_buffer)
+        io = StringIO.new(zip_buffer)
+
+        zip_file = if using_rubyzip_3?
+          Zip::File.new(io, buffer: true)
+        else
+          Zip::File.new(io, false, true)
+        end
+
+        zip_file.read('content.xml')
+      end
+
+      def using_rubyzip_3?
+        Gem.loaded_specs['rubyzip'].version >= Gem::Version.new('3.0.0')
+      end
 
       def pretty_xml(document)
         buffer = ""

--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.description = %q{Library for reading/writing OpenOffice Calc documents.}
   s.license     = "GPL-3.0"
 
-  s.add_runtime_dependency     "rubyzip", "~>2.3.0"
+  s.add_runtime_dependency     "rubyzip", ">=2.3.0"
   s.add_development_dependency "rspec",   "~>3.9.0"
 
   s.add_development_dependency "rake",   "~>13.0"


### PR DESCRIPTION
Rubyzip v3 is actually not used, since it's not released yet, but the change allows a user to install v3 separately, and, when installing the Spreadbase gem, that will be used:

```rb
source 'https://rubygems.org'

gem 'rubyzip', git: 'https://github.com/rubyzip/rubyzip', branch: 'master'
gem 'spreadbase', '=0.4.0'
```

See #26.