### PR TITLE
Update bundled gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-if Gem.ruby_version >= Gem::Version.new('3.0.0')
-  gem 'rexml'
-end

--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.description = %q{Library for reading/writing OpenOffice Calc documents.}
   s.license     = "GPL-3.0"
 
-  s.add_runtime_dependency     "rubyzip", ">=2.3.0"
-  s.add_runtime_dependency     "bigdecimal", "~> 3.1", ">= 3.1.5"
-  s.add_development_dependency "rspec",   "~>3.12.0"
+  s.add_runtime_dependency "rubyzip",    ">= 2.3.0"
+  s.add_runtime_dependency "bigdecimal", "~> 3.1", ">= 3.1.5"
 
-  s.add_development_dependency "rake",   "~>13.0"
+  s.add_development_dependency "rspec", "~> 3.12.0"
+  s.add_development_dependency "rake",  "~> 13.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,temp,utils}/*`.split("\n")

--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license     = "GPL-3.0"
 
   s.add_runtime_dependency "rubyzip",    ">= 2.3.0"
-  s.add_runtime_dependency "bigdecimal", "~> 3.1", ">= 3.1.5"
+  s.add_runtime_dependency "bigdecimal", ">= 3.0.0"
 
   s.add_development_dependency "rspec", "~> 3.12.0"
   s.add_development_dependency "rake",  "~> 13.0"

--- a/spreadbase.gemspec
+++ b/spreadbase.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "rubyzip",    ">= 2.3.0"
   s.add_runtime_dependency "bigdecimal", ">= 3.0.0"
+  s.add_runtime_dependency "rexml",      ">= 3.2.4"
 
   s.add_development_dependency "rspec", "~> 3.12.0"
   s.add_development_dependency "rake",  "~> 13.0"


### PR DESCRIPTION
- bigdecimal: lowered requirement (now >= 3.0.0)
- rexml: moved to gemspec and restricted (now >= 3.2.4)

Closes #38.